### PR TITLE
Fix loops_per_tick in timer_calibrate

### DIFF
--- a/src/devices/timer.c
+++ b/src/devices/timer.c
@@ -60,7 +60,7 @@ timer_calibrate (void)
   /* Refine the next 8 bits of loops_per_tick. */
   high_bit = loops_per_tick;
   for (test_bit = high_bit >> 1; test_bit != high_bit >> 10; test_bit >>= 1)
-    if (!too_many_loops (high_bit | test_bit))
+    if (!too_many_loops (loops_per_tick | test_bit))
       loops_per_tick |= test_bit;
 
   printf ("%'"PRIu64" loops/s.\n", (uint64_t) loops_per_tick * TIMER_FREQ);


### PR DESCRIPTION
Fixed a mistake in timer_calibrate.
In this function, loops_per_tick is to be estimated, and then fine-tuned.
in file timer.c line 61:
high_bit is set as initial loops_per_tick (greatest power of 2 loops, which is still smaller than a tick)
high bit NEVER CHANGES.
test_bit is initialized to high_bit, and in a loop, test_bit is being tested to be ORed with loops_per_tick in a binary-search fashion.
The condition is taking high_bit | test_bit, which is not correct.
Once this test passes, meaning (high_bit | test_bit) loops are smaller than a tick, it will pass for the rest of the iterations of the for loop as well.
That will cause it to kind of over estimate the number. (setting extra digits to 1)

After fixing it, I tested the solutions, and they all pass all tests.